### PR TITLE
Fix edge schema

### DIFF
--- a/src/resolvers/edge.js
+++ b/src/resolvers/edge.js
@@ -39,12 +39,8 @@ const edgeResolvers = {
     },
 
     async deleteEdge(root, { id }, { models, me }) {
-      const checkVertexOwner = await isVertexOwner(
-        null,
-        id.split("")[1],
-        models,
-        me
-      );
+      const sourceId = id.match(/e(\d+)/)[1];
+      const checkVertexOwner = await isVertexOwner(null, sourceId, models, me);
 
       if (!isAuthenticated(me)) {
         const res = new Response(

--- a/src/schema/edge.js
+++ b/src/schema/edge.js
@@ -3,7 +3,7 @@ const { gql } = require("apollo-server-express");
 const edgeSchema = gql`
   extend type Mutation {
     createEdge(sourceId: ID!, targetId: ID!): EdgeMutationResponse!
-    deleteEdge(id: ID!): EdgeMutationResponse!
+    deleteEdge(id: String!): EdgeMutationResponse!
   }
 
   type Edge {


### PR DESCRIPTION
- changes deleteEdge mutation's id type to string in edge schema 
- sourceId is now correctly extracted from edge id in deleteEdge resolver